### PR TITLE
fix: Correctly construct backend URL in API proxy route

### DIFF
--- a/src/app/api/[...path]/route.js
+++ b/src/app/api/[...path]/route.js
@@ -6,18 +6,15 @@ async function handler(request, context) {
   const backendUrl = process.env.API_BASE_URL_SERVER;
 
   try {
-    const response = await fetch(
-      `<span class="math-inline">\{backendUrl\}/</span>{path}`,
-      {
-        method: request.method,
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: request.headers.get("Authorization"),
-        },
-        body: request.method !== "GET" ? await request.text() : null,
-        cache: "no-store",
-      }
-    );
+    const response = await fetch(`${backendUrl}/${path}`, {
+      method: request.method,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: request.headers.get("Authorization"),
+      },
+      body: request.method !== "GET" ? await request.text() : null,
+      cache: "no-store",
+    });
 
     const contentType = response.headers.get("content-type");
     if (contentType && contentType.includes("application/json")) {


### PR DESCRIPTION
The template string used to construct the backend URL in the API proxy route was malformed, causing requests to fail. This commit corrects the template string to properly interpolate the `backendUrl` and `path` variables, ensuring that API requests are correctly routed to the backend server. The previous version was missing a `/` between the base URL and the path.
